### PR TITLE
Fixing 'bigdecimal' LoadError

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,4 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
+gem "bigdecimal"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    bigdecimal (1.4.3)
     colorator (1.1.0)
     concurrent-ruby (1.1.4)
     em-websocket (0.5.1)
@@ -65,6 +66,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bigdecimal
   jekyll (~> 3.8.5)
   jekyll-feed (~> 0.6)
   minima (~> 2.0)


### PR DESCRIPTION
Fixes :
```usr/share/rubygems/rubygems/core_ext/kernel_require.rb:59:in `require': cannot load such file -- bigdecimal (LoadError)```

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>